### PR TITLE
feat: HISTORY.mdの戦略に基づくE2Eテスト実装

### DIFF
--- a/e2e/operations/draft-operations.ts
+++ b/e2e/operations/draft-operations.ts
@@ -1,0 +1,169 @@
+/**
+ * ドラフト作成・参加に関する操作をまとめたクラス
+ */
+
+import { type Page, expect } from '@playwright/test';
+import { selectors, getLocator } from '../utils/selectors';
+import { timeouts, testUrls } from '../utils/test-data';
+
+export class DraftOperations {
+  constructor(private page: Page) {}
+
+  /**
+   * TOPページからドラフトを作成
+   */
+  async createNewDraft(): Promise<void> {
+    // TOPページに移動
+    await this.page.goto(testUrls.top);
+    
+    // ドラフト作成ボタンをクリック
+    const createButton = this.page.getByTestId(selectors.top.createDraftButton);
+    await expect(createButton).toBeVisible();
+    await createButton.click();
+    
+    // ロビーページへの遷移を待つ
+    await this.page.waitForURL(/\/lobby\/[a-zA-Z0-9-]+/, {
+      timeout: timeouts.navigation,
+    });
+  }
+
+  /**
+   * 4桁コードでドラフトに参加
+   */
+  async joinWithCode(code: string): Promise<void> {
+    // 参加ページに移動
+    await this.page.goto(testUrls.join);
+    
+    // コード入力フィールドに入力
+    const codeInput = this.page.getByTestId(selectors.join.codeInput);
+    await expect(codeInput).toBeVisible();
+    await codeInput.fill(code);
+    
+    // 参加ボタンをクリック
+    const submitButton = this.page.getByTestId(selectors.join.submitButton);
+    await submitButton.click();
+    
+    // ロビーページへの遷移を待つ
+    await this.page.waitForURL(/\/lobby\/[a-zA-Z0-9-]+/, {
+      timeout: timeouts.navigation,
+    });
+  }
+
+  /**
+   * URLでドラフトに参加
+   */
+  async joinWithUrl(url: string): Promise<void> {
+    // 参加ページに移動
+    await this.page.goto(testUrls.join);
+    
+    // URL入力フィールドに入力
+    const urlInput = this.page.getByTestId(selectors.join.urlInput);
+    await expect(urlInput).toBeVisible();
+    await urlInput.fill(url);
+    
+    // 参加ボタンをクリック
+    const submitButton = this.page.getByTestId(selectors.join.submitButton);
+    await submitButton.click();
+    
+    // ロビーページへの遷移を待つ
+    await this.page.waitForURL(/\/lobby\/[a-zA-Z0-9-]+/, {
+      timeout: timeouts.navigation,
+    });
+  }
+
+  /**
+   * 履歴から参加
+   */
+  async joinFromHistory(groupId: string): Promise<void> {
+    // 参加ページに移動
+    await this.page.goto(testUrls.join);
+    
+    // 履歴リストが表示されるまで待つ
+    const recentList = this.page.getByTestId(selectors.join.recentMeetingsList);
+    await expect(recentList).toBeVisible();
+    
+    // 特定のグループをクリック
+    const meetingItem = this.page.getByTestId(selectors.join.recentMeetingItem(groupId));
+    await expect(meetingItem).toBeVisible();
+    await meetingItem.click();
+    
+    // ロビーページへの遷移を待つ
+    await this.page.waitForURL(`/lobby/${groupId}`, {
+      timeout: timeouts.navigation,
+    });
+  }
+
+  /**
+   * 現在のグループIDを取得
+   */
+  async getCurrentGroupId(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/\/lobby\/([a-zA-Z0-9-]+)/);
+    if (!match) {
+      throw new Error('グループIDが取得できません');
+    }
+    return match[1];
+  }
+
+  /**
+   * 現在のグループコードを取得（ロビーページから）
+   */
+  async getGroupCode(): Promise<string> {
+    // ロビーページにいることを確認
+    await expect(this.page).toHaveURL(/\/lobby\/[a-zA-Z0-9-]+/);
+    
+    // グループコードを表示している要素を探す
+    // TODO: 実際の実装に合わせてセレクターを調整
+    const codeElement = this.page.locator('[data-testid="group-code"]');
+    const code = await codeElement.textContent();
+    
+    if (!code) {
+      throw new Error('グループコードが取得できません');
+    }
+    
+    // 4桁の数字のみを抽出
+    const match = code.match(/\d{4}/);
+    if (!match) {
+      throw new Error('有効なグループコードが見つかりません');
+    }
+    
+    return match[0];
+  }
+
+  /**
+   * グループ情報が正しく表示されているか確認
+   */
+  async verifyGroupInfo(expectedTitle?: string): Promise<void> {
+    const titleElement = this.page.getByTestId(selectors.lobby.groupInfo.title);
+    await expect(titleElement).toBeVisible();
+    
+    if (expectedTitle) {
+      await expect(titleElement).toContainText(expectedTitle);
+    }
+    
+    // 参加者リストが表示されているか確認
+    const participantList = this.page.getByTestId(selectors.lobby.groupInfo.participantList);
+    await expect(participantList).toBeVisible();
+  }
+
+  /**
+   * エラーメッセージが表示されているか確認
+   */
+  async verifyErrorMessage(expectedMessage: string): Promise<void> {
+    const errorElement = this.page.getByTestId(selectors.common.errorMessage);
+    await expect(errorElement).toBeVisible();
+    await expect(errorElement).toContainText(expectedMessage);
+  }
+
+  /**
+   * ローディング状態が解消されるまで待つ
+   */
+  async waitForLoadingComplete(): Promise<void> {
+    const loading = this.page.getByTestId(selectors.common.loading);
+    
+    // ローディングが表示されている場合は非表示になるまで待つ
+    if (await loading.isVisible()) {
+      await expect(loading).toBeHidden({ timeout: timeouts.long });
+    }
+  }
+}

--- a/e2e/operations/user-operations.ts
+++ b/e2e/operations/user-operations.ts
@@ -1,0 +1,156 @@
+/**
+ * ユーザー作成・選択に関する操作をまとめたクラス
+ */
+
+import { type Page, expect } from '@playwright/test';
+import { selectors } from '../utils/selectors';
+import { timeouts } from '../utils/test-data';
+import type { TestUser } from '../utils/test-data';
+
+export class UserOperations {
+  constructor(private page: Page) {}
+
+  /**
+   * 新規ユーザーを作成
+   */
+  async createNewUser(user: TestUser): Promise<void> {
+    // ロビーページにいることを確認
+    await expect(this.page).toHaveURL(/\/lobby\/[a-zA-Z0-9-]+/);
+    
+    // ユーザー選択ステップで「新規作成」ボタンをクリック
+    const createNewButton = this.page.getByTestId(selectors.lobby.userSelect.createNewButton);
+    await expect(createNewButton).toBeVisible();
+    await createNewButton.click();
+    
+    // ユーザー作成ステップに遷移したことを確認
+    const createContainer = this.page.getByTestId(selectors.lobby.userCreate.container);
+    await expect(createContainer).toBeVisible();
+    
+    // 名前を入力
+    const nameInput = this.page.getByTestId(selectors.lobby.userCreate.nameInput);
+    await nameInput.fill(user.name);
+    
+    // アバターを選択
+    const avatarOption = this.page.getByTestId(
+      selectors.lobby.userCreate.avatarOption(user.avatarId)
+    );
+    await avatarOption.click();
+    
+    // 確定ボタンをクリック
+    const confirmButton = this.page.getByTestId(selectors.lobby.userCreate.confirmButton);
+    await confirmButton.click();
+    
+    // ドラフトページへの遷移を待つ（または次のステップへ）
+    await this.waitForUserCreationComplete();
+  }
+
+  /**
+   * 既存ユーザーを選択
+   */
+  async selectExistingUser(userId: string): Promise<void> {
+    // ロビーページにいることを確認
+    await expect(this.page).toHaveURL(/\/lobby\/[a-zA-Z0-9-]+/);
+    
+    // ユーザー選択ステップが表示されていることを確認
+    const selectContainer = this.page.getByTestId(selectors.lobby.userSelect.container);
+    await expect(selectContainer).toBeVisible();
+    
+    // ユーザーリストから選択
+    const userItem = this.page.getByTestId(selectors.lobby.userSelect.userItem(userId));
+    await expect(userItem).toBeVisible();
+    await userItem.click();
+    
+    // 選択完了を待つ
+    await this.waitForUserSelectionComplete();
+  }
+
+  /**
+   * 現在のステップを確認
+   */
+  async verifyCurrentStep(stepNumber: number): Promise<void> {
+    const stepIndicator = this.page.getByTestId(selectors.lobby.currentStep(stepNumber));
+    await expect(stepIndicator).toHaveAttribute('aria-current', 'step');
+  }
+
+  /**
+   * 参加者リストに特定のユーザーが表示されているか確認
+   */
+  async verifyUserInParticipantList(userName: string): Promise<void> {
+    const participantList = this.page.getByTestId(selectors.lobby.groupInfo.participantList);
+    await expect(participantList).toBeVisible();
+    
+    // 参加者リスト内にユーザー名が含まれているか確認
+    await expect(participantList).toContainText(userName);
+  }
+
+  /**
+   * 参加者数を確認
+   */
+  async verifyParticipantCount(expectedCount: number): Promise<void> {
+    const countElement = this.page.getByTestId(selectors.lobby.groupInfo.participantCount);
+    await expect(countElement).toBeVisible();
+    await expect(countElement).toContainText(expectedCount.toString());
+  }
+
+  /**
+   * アバター選択状態を確認
+   */
+  async verifyAvatarSelected(avatarId: number): Promise<void> {
+    const avatarOption = this.page.getByTestId(
+      selectors.lobby.userCreate.avatarOption(avatarId)
+    );
+    // 選択状態を示す属性やクラスを確認（実装に応じて調整）
+    await expect(avatarOption).toHaveAttribute('data-selected', 'true');
+  }
+
+  /**
+   * 名前入力のバリデーションエラーを確認
+   */
+  async verifyNameValidationError(errorMessage: string): Promise<void> {
+    // 名前入力フィールド周辺のエラーメッセージを確認
+    const nameInput = this.page.getByTestId(selectors.lobby.userCreate.nameInput);
+    const errorElement = nameInput.locator('..').locator('[role="alert"]');
+    await expect(errorElement).toBeVisible();
+    await expect(errorElement).toContainText(errorMessage);
+  }
+
+  /**
+   * ユーザー作成完了を待つ
+   */
+  private async waitForUserCreationComplete(): Promise<void> {
+    // ドラフトページへの遷移、または完了メッセージを待つ
+    await Promise.race([
+      this.page.waitForURL(/\/draft\/[a-zA-Z0-9-]+/, {
+        timeout: timeouts.navigation,
+      }),
+      // または次のステップへの遷移を待つ
+      this.page.waitForSelector(
+        `[data-testid="${selectors.lobby.userSelect.container}"]`,
+        { state: 'hidden', timeout: timeouts.medium }
+      ),
+    ]);
+  }
+
+  /**
+   * ユーザー選択完了を待つ
+   */
+  private async waitForUserSelectionComplete(): Promise<void> {
+    // ドラフトページへの遷移を待つ
+    await this.page.waitForURL(/\/draft\/[a-zA-Z0-9-]+/, {
+      timeout: timeouts.navigation,
+    });
+  }
+
+  /**
+   * 戻るボタンをクリック
+   */
+  async clickBackButton(): Promise<void> {
+    const backButton = this.page.getByTestId(selectors.lobby.userCreate.backButton);
+    await expect(backButton).toBeVisible();
+    await backButton.click();
+    
+    // ユーザー選択ステップに戻ったことを確認
+    const selectContainer = this.page.getByTestId(selectors.lobby.userSelect.container);
+    await expect(selectContainer).toBeVisible();
+  }
+}

--- a/e2e/tests/organizer-journey.test.ts
+++ b/e2e/tests/organizer-journey.test.ts
@@ -1,0 +1,147 @@
+/**
+ * 主催者シナリオのE2Eテスト
+ * ユーザーストーリー: ドラフト会議を開催したい主催者がグループを作成し、参加者を待つ
+ */
+
+import { test, expect } from '@playwright/test';
+import { DraftOperations } from '../operations/draft-operations';
+import { UserOperations } from '../operations/user-operations';
+import { predefinedUsers, timeouts } from '../utils/test-data';
+import { selectors } from '../utils/selectors';
+
+test.describe('主催者シナリオ', () => {
+  let draftOps: DraftOperations;
+  let userOps: UserOperations;
+
+  test.beforeEach(async ({ page }) => {
+    draftOps = new DraftOperations(page);
+    userOps = new UserOperations(page);
+  });
+
+  test('新規ドラフトを作成し、主催者として参加する', async ({ page }) => {
+    // Step 1: TOPページからドラフトを作成
+    await test.step('ドラフトを作成', async () => {
+      await draftOps.createNewDraft();
+      
+      // ロビーページに遷移したことを確認
+      await expect(page).toHaveURL(/\/lobby\/[a-zA-Z0-9-]+/);
+    });
+
+    // Step 2: グループ情報を確認
+    const groupId = await test.step('グループ情報を確認', async () => {
+      await draftOps.verifyGroupInfo();
+      
+      // グループIDを取得（後で参加者に共有するため）
+      const id = await draftOps.getCurrentGroupId();
+      expect(id).toBeTruthy();
+      
+      return id;
+    });
+
+    // Step 3: 主催者としてユーザーを作成
+    await test.step('主催者ユーザーを作成', async () => {
+      await userOps.createNewUser(predefinedUsers.organizer);
+      
+      // 参加者リストに主催者が表示されることを確認
+      await userOps.verifyUserInParticipantList(predefinedUsers.organizer.name);
+      await userOps.verifyParticipantCount(1);
+    });
+
+    // Step 4: グループコードを確認（参加者に共有用）
+    const groupCode = await test.step('グループコードを取得', async () => {
+      const code = await draftOps.getGroupCode();
+      expect(code).toMatch(/^\d{4}$/); // 4桁の数字であることを確認
+      
+      console.log(`作成されたグループ: ID=${groupId}, Code=${code}`);
+      return code;
+    });
+
+    // Step 5: 参加者を待つ状態を確認
+    await test.step('参加者待機状態を確認', async () => {
+      // ドラフトページに遷移していることを確認（実装により異なる可能性）
+      // または、ロビーページで待機状態になっていることを確認
+      
+      // 参加者リストが更新可能な状態であることを確認
+      const participantList = page.getByTestId(selectors.lobby.groupInfo.participantList);
+      await expect(participantList).toBeVisible();
+    });
+  });
+
+  test('作成したドラフトの設定を変更する', async ({ page }) => {
+    // Step 1: ドラフトを作成
+    await test.step('ドラフトを作成', async () => {
+      await draftOps.createNewDraft();
+    });
+
+    // Step 2: 主催者として参加
+    await test.step('主催者として参加', async () => {
+      await userOps.createNewUser(predefinedUsers.organizer);
+    });
+
+    // Step 3: 設定を変更（将来実装）
+    await test.step('ドラフト設定を変更', async () => {
+      // TODO: ドラフト設定変更機能が実装されたら追加
+      // - ドラフト名の変更
+      // - 参加人数制限の設定
+      // - ドラフト方式の選択
+      // - タイマー設定
+    });
+  });
+
+  test('既存ユーザーとして新規ドラフトを作成', async ({ page }) => {
+    // Step 1: ドラフトを作成
+    await test.step('ドラフトを作成', async () => {
+      await draftOps.createNewDraft();
+    });
+
+    // Step 2: 既存ユーザーが表示される場合は選択
+    await test.step('既存ユーザーを選択または新規作成', async () => {
+      // ユーザー選択画面が表示されることを確認
+      const userSelectContainer = page.getByTestId(selectors.lobby.userSelect.container);
+      await expect(userSelectContainer).toBeVisible();
+      
+      // 既存ユーザーリストを確認
+      const existingUserList = page.getByTestId(selectors.lobby.userSelect.existingUserList);
+      
+      // 既存ユーザーがいる場合は選択、いない場合は新規作成
+      if (await existingUserList.isVisible()) {
+        // TODO: 既存ユーザーの選択ロジック
+        // 現時点では新規作成を行う
+        await userOps.createNewUser(predefinedUsers.organizer);
+      } else {
+        await userOps.createNewUser(predefinedUsers.organizer);
+      }
+    });
+  });
+
+  test('ドラフト作成後、参加者の入室を確認', async ({ page, context }) => {
+    let groupCode: string;
+
+    // Step 1: 主催者がドラフトを作成
+    await test.step('主催者がドラフトを作成', async () => {
+      await draftOps.createNewDraft();
+      await userOps.createNewUser(predefinedUsers.organizer);
+      
+      // グループコードを取得
+      groupCode = await draftOps.getGroupCode();
+    });
+
+    // Step 2: 別タブで参加者が入室（リアルタイム同期のテスト）
+    await test.step('参加者が別タブから入室', async () => {
+      // 新しいタブを開く
+      const participantPage = await context.newPage();
+      const participantDraftOps = new DraftOperations(participantPage);
+      const participantUserOps = new UserOperations(participantPage);
+      
+      // 参加者がコードで参加
+      await participantDraftOps.joinWithCode(groupCode);
+      await participantUserOps.createNewUser(predefinedUsers.participant1);
+      
+      // 主催者側で参加者が表示されることを確認
+      await userOps.verifyUserInParticipantList(predefinedUsers.participant1.name);
+      await userOps.verifyParticipantCount(2);
+      
+      await participantPage.close();
+    });
+  });
+});

--- a/e2e/tests/participant-journey.test.ts
+++ b/e2e/tests/participant-journey.test.ts
@@ -1,0 +1,219 @@
+/**
+ * 参加者シナリオのE2Eテスト
+ * ユーザーストーリー: ドラフト会議に参加したい人が、コード・URL・履歴から参加する
+ */
+
+import { test, expect } from '@playwright/test';
+import { DraftOperations } from '../operations/draft-operations';
+import { UserOperations } from '../operations/user-operations';
+import { predefinedUsers, errorMessages, testUrls } from '../utils/test-data';
+import { selectors } from '../utils/selectors';
+
+test.describe('参加者シナリオ', () => {
+  let draftOps: DraftOperations;
+  let userOps: UserOperations;
+
+  test.beforeEach(async ({ page }) => {
+    draftOps = new DraftOperations(page);
+    userOps = new UserOperations(page);
+  });
+
+  test('4桁コードでドラフトに参加する', async ({ page, context }) => {
+    let groupCode: string;
+
+    // 準備: 別タブで主催者がドラフトを作成
+    await test.step('主催者がドラフトを準備', async () => {
+      const organizerPage = await context.newPage();
+      const organizerDraftOps = new DraftOperations(organizerPage);
+      const organizerUserOps = new UserOperations(organizerPage);
+      
+      await organizerDraftOps.createNewDraft();
+      await organizerUserOps.createNewUser(predefinedUsers.organizer);
+      groupCode = await organizerDraftOps.getGroupCode();
+      
+      // 主催者ページは開いたままにしておく（リアルタイム同期の確認用）
+    });
+
+    // Step 1: コードで参加
+    await test.step('4桁コードで参加', async () => {
+      await draftOps.joinWithCode(groupCode);
+      
+      // ロビーページに遷移したことを確認
+      await expect(page).toHaveURL(/\/lobby\/[a-zA-Z0-9-]+/);
+    });
+
+    // Step 2: グループ情報を確認
+    await test.step('グループ情報を確認', async () => {
+      await draftOps.verifyGroupInfo();
+      
+      // 主催者が既に参加していることを確認
+      await userOps.verifyUserInParticipantList(predefinedUsers.organizer.name);
+      await userOps.verifyParticipantCount(1);
+    });
+
+    // Step 3: 参加者としてユーザーを作成
+    await test.step('参加者ユーザーを作成', async () => {
+      await userOps.createNewUser(predefinedUsers.participant1);
+      
+      // 参加者リストに自分が追加されたことを確認
+      await userOps.verifyUserInParticipantList(predefinedUsers.participant1.name);
+      await userOps.verifyParticipantCount(2);
+    });
+  });
+
+  test('URLでドラフトに参加する', async ({ page, context }) => {
+    let groupId: string;
+    let lobbyUrl: string;
+
+    // 準備: 主催者がドラフトを作成
+    await test.step('主催者がドラフトを準備', async () => {
+      const organizerPage = await context.newPage();
+      const organizerDraftOps = new DraftOperations(organizerPage);
+      const organizerUserOps = new UserOperations(organizerPage);
+      
+      await organizerDraftOps.createNewDraft();
+      groupId = await organizerDraftOps.getCurrentGroupId();
+      lobbyUrl = `${testUrls.base}/lobby/${groupId}`;
+      await organizerUserOps.createNewUser(predefinedUsers.organizer);
+    });
+
+    // Step 1: URLで参加
+    await test.step('URLで参加', async () => {
+      await draftOps.joinWithUrl(lobbyUrl);
+      
+      // ロビーページに遷移したことを確認
+      await expect(page).toHaveURL(`/lobby/${groupId}`);
+    });
+
+    // Step 2: 参加者として登録
+    await test.step('参加者として登録', async () => {
+      await userOps.createNewUser(predefinedUsers.participant2);
+      await userOps.verifyParticipantCount(2);
+    });
+  });
+
+  test('無効なコードで参加を試みる', async ({ page }) => {
+    const invalidCode = '0000'; // 存在しないコード
+
+    await test.step('無効なコードで参加を試みる', async () => {
+      await page.goto(testUrls.join);
+      
+      // コード入力
+      const codeInput = page.getByTestId(selectors.join.codeInput);
+      await codeInput.fill(invalidCode);
+      
+      // 参加ボタンをクリック
+      const submitButton = page.getByTestId(selectors.join.submitButton);
+      await submitButton.click();
+      
+      // エラーメッセージが表示されることを確認
+      await draftOps.verifyErrorMessage(errorMessages.invalidCode);
+      
+      // ページ遷移しないことを確認
+      await expect(page).toHaveURL(testUrls.join);
+    });
+  });
+
+  test('履歴から再参加する', async ({ page, context }) => {
+    let groupId: string;
+    let groupCode: string;
+
+    // Step 1: 初回参加
+    await test.step('初回参加してグループに入る', async () => {
+      // 主催者がドラフトを作成
+      const organizerPage = await context.newPage();
+      const organizerDraftOps = new DraftOperations(organizerPage);
+      const organizerUserOps = new UserOperations(organizerPage);
+      
+      await organizerDraftOps.createNewDraft();
+      groupId = await organizerDraftOps.getCurrentGroupId();
+      groupCode = await organizerDraftOps.getGroupCode();
+      await organizerUserOps.createNewUser(predefinedUsers.organizer);
+      
+      // 参加者として参加
+      await draftOps.joinWithCode(groupCode);
+      await userOps.createNewUser(predefinedUsers.participant1);
+    });
+
+    // Step 2: 一度離脱して履歴から再参加
+    await test.step('履歴から再参加', async () => {
+      // TOPページに戻る
+      await page.goto(testUrls.top);
+      
+      // 参加ページに移動
+      await page.goto(testUrls.join);
+      
+      // 履歴リストが表示されることを確認
+      const recentList = page.getByTestId(selectors.join.recentMeetingsList);
+      await expect(recentList).toBeVisible();
+      
+      // 履歴から参加
+      await draftOps.joinFromHistory(groupId);
+      
+      // ロビーページに遷移したことを確認
+      await expect(page).toHaveURL(`/lobby/${groupId}`);
+      
+      // 既存ユーザーとして認識されることを確認
+      const existingUserList = page.getByTestId(selectors.lobby.userSelect.existingUserList);
+      await expect(existingUserList).toBeVisible();
+    });
+  });
+
+  test('参加フォームのバリデーション', async ({ page }) => {
+    await page.goto(testUrls.join);
+
+    await test.step('空のコードで参加を試みる', async () => {
+      const submitButton = page.getByTestId(selectors.join.submitButton);
+      await submitButton.click();
+      
+      // バリデーションエラーが表示されることを確認
+      const codeInput = page.getByTestId(selectors.join.codeInput);
+      await expect(codeInput).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    await test.step('不正な形式のコードを入力', async () => {
+      const codeInput = page.getByTestId(selectors.join.codeInput);
+      
+      // 3桁の数字
+      await codeInput.fill('123');
+      await expect(codeInput).toHaveAttribute('aria-invalid', 'true');
+      
+      // 文字を含む
+      await codeInput.fill('12AB');
+      await expect(codeInput).toHaveAttribute('aria-invalid', 'true');
+      
+      // 5桁の数字
+      await codeInput.fill('12345');
+      await expect(codeInput).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    await test.step('不正なURLを入力', async () => {
+      const urlInput = page.getByTestId(selectors.join.urlInput);
+      
+      // 不正なURL形式
+      await urlInput.fill('not-a-url');
+      const submitButton = page.getByTestId(selectors.join.submitButton);
+      await submitButton.click();
+      
+      await expect(urlInput).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  test('複数の参加方法を切り替える', async ({ page }) => {
+    await page.goto(testUrls.join);
+
+    await test.step('コード入力とURL入力を切り替える', async () => {
+      const codeInput = page.getByTestId(selectors.join.codeInput);
+      const urlInput = page.getByTestId(selectors.join.urlInput);
+      
+      // コードを入力
+      await codeInput.fill('1234');
+      
+      // URLフィールドに切り替えて入力
+      await urlInput.fill('https://example.com/lobby/test-id');
+      
+      // コードフィールドがクリアされることを確認（実装による）
+      // または両方入力できる場合は、どちらが優先されるか確認
+    });
+  });
+});

--- a/e2e/utils/selectors.ts
+++ b/e2e/utils/selectors.ts
@@ -1,0 +1,99 @@
+/**
+ * E2Eテスト用のセレクター定義
+ * data-testid属性を使用した要素選択の一元管理
+ */
+
+export const selectors = {
+  // 共通要素
+  common: {
+    themeToggle: 'theme-toggle',
+    loading: 'loading-spinner',
+    errorMessage: 'error-message',
+  },
+
+  // TOPページ
+  top: {
+    heroSection: 'hero-section',
+    createDraftButton: 'create-draft-button',
+    joinDraftButton: 'join-draft-button',
+    howToSection: 'how-to-section',
+    stepCard: (step: number) => `step-card-${step}`,
+  },
+
+  // 参加ページ
+  join: {
+    joinForm: 'join-form',
+    codeInput: 'join-code-input',
+    urlInput: 'join-url-input',
+    submitButton: 'join-submit-button',
+    recentMeetingsList: 'recent-meetings-list',
+    recentMeetingItem: (id: string) => `recent-meeting-${id}`,
+    joinHint: 'join-hint',
+  },
+
+  // ロビーページ
+  lobby: {
+    container: 'lobby-container',
+    stepIndicator: 'step-indicator',
+    currentStep: (step: number) => `step-${step}`,
+    
+    // ユーザー選択ステップ
+    userSelect: {
+      container: 'user-select-container',
+      existingUserList: 'existing-user-list',
+      userItem: (id: string) => `user-item-${id}`,
+      createNewButton: 'create-new-user-button',
+    },
+    
+    // ユーザー作成ステップ
+    userCreate: {
+      container: 'user-create-container',
+      nameInput: 'user-name-input',
+      avatarSelector: 'avatar-selector',
+      avatarOption: (id: number) => `avatar-${id}`,
+      confirmButton: 'user-create-confirm',
+      backButton: 'user-create-back',
+    },
+    
+    // グループ情報
+    groupInfo: {
+      title: 'group-title',
+      participantCount: 'participant-count',
+      participantList: 'participant-list',
+      participantItem: (id: string) => `participant-${id}`,
+    },
+  },
+
+  // ドラフトページ（将来実装用）
+  draft: {
+    container: 'draft-container',
+    chatArea: 'chat-area',
+    chatInput: 'chat-input',
+    chatSendButton: 'chat-send-button',
+    slotArea: 'slot-area',
+    slotItem: (index: number) => `slot-${index}`,
+    submitButton: 'draft-submit-button',
+  },
+
+  // モーダル・ダイアログ
+  modal: {
+    container: 'modal-container',
+    closeButton: 'modal-close-button',
+    confirmButton: 'modal-confirm-button',
+    cancelButton: 'modal-cancel-button',
+  },
+} as const;
+
+/**
+ * data-testid属性セレクターを生成
+ */
+export function getTestId(selector: string): string {
+  return `[data-testid="${selector}"]`;
+}
+
+/**
+ * Playwrightのlocator用セレクターを生成
+ */
+export function getLocator(selector: string): string {
+  return `data-testid=${selector}`;
+}

--- a/e2e/utils/test-data.ts
+++ b/e2e/utils/test-data.ts
@@ -1,0 +1,134 @@
+/**
+ * E2Eテスト用のテストデータ定義
+ */
+
+/**
+ * テスト用ユーザー情報
+ */
+export interface TestUser {
+  id: string;
+  name: string;
+  avatarId: number;
+}
+
+/**
+ * テスト用グループ情報
+ */
+export interface TestGroup {
+  id: string;
+  name: string;
+  code: string;
+  createdBy: string;
+}
+
+/**
+ * テスト用ユーザーを生成
+ */
+export function createTestUser(overrides?: Partial<TestUser>): TestUser {
+  const randomAvatarId = Math.floor(Math.random() * 18) + 1; // 1-18
+  return {
+    id: crypto.randomUUID(),
+    name: `テストユーザー_${Date.now()}`,
+    avatarId: randomAvatarId,
+    ...overrides,
+  };
+}
+
+/**
+ * テスト用グループを生成
+ */
+export function createTestGroup(overrides?: Partial<TestGroup>): TestGroup {
+  const id = overrides?.id || crypto.randomUUID();
+  return {
+    id,
+    name: `テストドラフト_${Date.now()}`,
+    code: generateTestCode(),
+    createdBy: 'test-user',
+    ...overrides,
+  };
+}
+
+/**
+ * テスト用の4桁コードを生成
+ */
+export function generateTestCode(): string {
+  return Math.floor(1000 + Math.random() * 9000).toString();
+}
+
+/**
+ * 事前定義されたテストユーザー
+ */
+export const predefinedUsers = {
+  organizer: createTestUser({
+    name: '主催者テスト',
+    avatarId: 1,
+  }),
+  participant1: createTestUser({
+    name: '参加者1',
+    avatarId: 2,
+  }),
+  participant2: createTestUser({
+    name: '参加者2',
+    avatarId: 3,
+  }),
+  latecomer: createTestUser({
+    name: '途中参加者',
+    avatarId: 4,
+  }),
+};
+
+/**
+ * テスト用のドラフトアイテム（将来実装用）
+ */
+export const draftItems = [
+  { id: '1', name: 'アイテムA', category: 'カテゴリ1' },
+  { id: '2', name: 'アイテムB', category: 'カテゴリ1' },
+  { id: '3', name: 'アイテムC', category: 'カテゴリ2' },
+  { id: '4', name: 'アイテムD', category: 'カテゴリ2' },
+  { id: '5', name: 'アイテムE', category: 'カテゴリ3' },
+];
+
+/**
+ * テスト用のチャットメッセージ
+ */
+export const testMessages = {
+  greeting: 'こんにちは！よろしくお願いします',
+  ready: '準備OK!',
+  thinking: 'どれにしようかな...',
+  decided: '決めました！',
+  conflict: 'かぶっちゃった！',
+};
+
+/**
+ * テスト用のエラーメッセージ
+ */
+export const errorMessages = {
+  invalidCode: 'コードが無効です',
+  groupNotFound: 'グループが見つかりません',
+  connectionError: '接続エラーが発生しました',
+  nameRequired: '名前を入力してください',
+  avatarRequired: 'アバターを選択してください',
+};
+
+/**
+ * タイムアウト設定（ミリ秒）
+ */
+export const timeouts = {
+  short: 1000,
+  medium: 3000,
+  long: 5000,
+  extraLong: 10000,
+  navigation: 5000,
+  animation: 500,
+};
+
+/**
+ * テスト環境のURL
+ */
+export const testUrls = {
+  base: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+  top: '/',
+  join: '/join',
+  lobby: (id: string) => `/lobby/${id}`,
+  draft: (id: string) => `/draft/${id}`,
+};


### PR DESCRIPTION
## 概要
E2Eテスト戦略（docs/E2E_TESTING_GUIDE.md）に基づき、Phase 1のユーザーシナリオベースE2Eテストを実装しました。

## 変更内容
- セレクター定義（selectors.ts）: data-testidによる要素選択の一元管理
- テストデータ（test-data.ts）: テスト用のユーザー、グループ、タイムアウト設定等
- operations層: 複雑な操作を再利用可能な形で抽象化
  - draft-operations.ts: ドラフト作成・参加操作
  - user-operations.ts: ユーザー作成・選択操作
- テストシナリオ:
  - organizer-journey.test.ts: 主催者のユーザージャーニー
  - participant-journey.test.ts: 参加者のユーザージャーニー

## 次のステップ
Phase 2、Phase 3の実装が必要です。まずはアプリケーション側にdata-testid属性を追加して、テストを実行可能にする必要があります。

Closes #72

Generated with [Claude Code](https://claude.ai/code)