### PR TITLE
🧹 VSCode設定クリーンアップ - 存在しないファイル参照削除

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,12 +26,7 @@
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "favorites.resources": [
-    {
-      "filePath": "src\\helpers\\auth\\middleware.ts",
-      "group": "Default"
-    }
-  ],
+  "favorites.resources": [],
   "claude-code.context.autoGenerate": true,
   "claude-code.context.updateTrigger": "onSave"
 }


### PR DESCRIPTION
## 📋 概要
VSCode設定から存在しないファイルへの参照を削除しました。

## 🛠️ 実装内容
- `.vscode/settings.json` から存在しない `src\\helpers\\auth\\middleware.ts` への参照を削除
- `favorites.resources` を空配列に変更
- JSON形式を維持

Closes #97

Generated with [Claude Code](https://claude.ai/code)