### PR TITLE
fix: BASE_URLをCloudflare Pagesのドメインに統一

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -14,7 +14,7 @@ import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
-const BASE_URL = 'https://online-draft.vercel.app';
+const BASE_URL = 'https://online-draft.pages.dev';
 
 type LocaleLayoutProps = {
   children: ReactNode;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { locales, defaultLocale } from '@/src/i18n/config';
 
-const BASE_URL = 'https://online-draft.vercel.app';
+const BASE_URL = 'https://online-draft.pages.dev';
 
 const getLocalePath = (locale: string, path: string) => {
   const prefix = locale === defaultLocale ? '' : `/${locale}`;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,4 +5,4 @@ Disallow: /draft/
 Disallow: /lobby/
 Disallow: /entry/
 
-Sitemap: https://online-draft.vercel.app/sitemap.xml
+Sitemap: https://online-draft.pages.dev/sitemap.xml


### PR DESCRIPTION
## 概要
メインのデプロイ先である `online-draft.pages.dev`（Cloudflare Pages）にBASE_URLを合わせ、Google Search Console登録に向けたSEO関連URLの整合性を確保するよ〜！

これまで `BASE_URL` が `online-draft.vercel.app` 固定で、sitemap.xml・canonical URL・OG URL・JSON-LD・robots.txtのSitemap参照すべてがVercelドメインを指していたんだけど、実際のメイン公開先はCloudflare Pagesなのでズレが発生してたよ〜🤔

ちなみに Google Search Console の **DNS認証は `.pages.dev` には絶対通らない**（Cloudflareがドメイン所有者だから）ので、URLプレフィックスプロパティ + HTMLタグ認証方式で登録予定。HTMLタグは既にコミット `e1faf6b1` で実装済み✨

## 変更内容
### 🔧 主な変更点
- [x] \`app/[locale]/layout.tsx\` の \`BASE_URL\` を \`https://online-draft.pages.dev\` に変更
- [x] \`app/sitemap.ts\` の \`BASE_URL\` を \`https://online-draft.pages.dev\` に変更
- [x] \`public/robots.txt\` の Sitemap参照を \`pages.dev\` に変更

### ✅ 追加/修正した機能
- sitemap.xml で生成されるURLが \`pages.dev\` ドメインベースになる
- metadataBase / OG URL / JSON-LD の参照ドメインを統一
- robots.txt の Sitemap ディレクティブを実際の公開URLに修正

### 🗑️ 削除した機能/ファイル
- なし

## 関連ISSUE
- Related to #407 (Google Search Console認証metaタグ追加)

## テスト方法
### 🧪 動作確認手順
1. デプロイ後 \`curl -s https://online-draft.pages.dev/sitemap.xml | head\` でURL先が \`pages.dev\` になっていることを確認
2. \`curl -s https://online-draft.pages.dev/robots.txt\` で Sitemap行が \`pages.dev\` になっていることを確認
3. \`curl -s https://online-draft.pages.dev/ | grep google-site-verification\` で認証メタタグが出力されていることを確認
4. Google Search Console の「URLプレフィックス」プロパティで \`https://online-draft.pages.dev\` を登録し、HTMLタグ認証が通ることを確認

### ✅ 品質チェック済み
- [x] \`pnpm lint\` - Lintエラーなし（154ファイル, 警告0）
- [x] \`pnpm type-check\` - TypeScriptエラーなし
- [x] \`pnpm build\` - ビルド成功（既存の警告のみ、新規警告なし）
- [ ] \`pnpm test\` - 静的URL変更のみのため影響なし（実行省略）
- [ ] \`pnpm storybook:test-ci\` - 静的URL変更のみのため影響なし（実行省略）
- [ ] \`pnpm e2e\` - 静的URL変更のみのため影響なし（実行省略）

## スクリーンショット
UI変更なしのためスクリーンショットなし

## 📝 レビュー観点
- [ ] \`pages.dev\` がメインの公開URLで本当に正しいか（カスタムドメイン未取得・Vercelデプロイ廃止判断はスコープ外）
- [ ] docs配下の \`AIO_IMPLEMENTATION.md\` / \`seo-improvement-plan.md\` に残っている \`vercel.app\` 参照は歴史的な計画書のため今回は変更していない点

## 📚 今後の作業
- [ ] Google Search Console で URLプレフィックスプロパティを登録 + サイトマップ送信
- [ ] 必要に応じて環境変数化（プレビューデプロイ対応）
- [ ] カスタムドメイン取得時には再度BASE_URL更新

🤖 Generated with [Claude Code](https://claude.ai/code)